### PR TITLE
Revert header to old version without title and subtitle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,8 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                 <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -74,10 +74,9 @@ body {
 header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 


### PR DESCRIPTION
Reverts the header to the old design by removing the title, subtitle, and horizontal border while keeping the theme toggle functional.

## Changes
- Removed "Course Materials Assistant" h1 header
- Removed subtitle "Ask questions about courses, instructors, and content"
- Removed horizontal border below header
- Updated header layout to align theme toggle to the right

Fixes #2

Generated with [Claude Code](https://claude.ai/code)